### PR TITLE
Listen for events on service start-up

### DIFF
--- a/service/baseservice.go
+++ b/service/baseservice.go
@@ -25,3 +25,6 @@ func (s *BaseService) GRPC() *grpc.Server { return nil }
 
 // Bus implements the [CloudService] interface.
 func (s *BaseService) Bus() MessageBus { return nil }
+
+// Events implements the [CloudService] interface.
+func (s *BaseService) Events() map[string]EventHandler { return nil }

--- a/service/cloudservice.go
+++ b/service/cloudservice.go
@@ -29,4 +29,9 @@ type CloudService interface {
 	// and subscribing to messages. Returns nil if the service is
 	// not publishing/subscribing messages.
 	Bus() MessageBus
+
+	// Events returns a map of events for which the service is
+	// listening, and their associated handlers. Returns nil if
+	// the service is not listening to events.
+	Events() map[string]EventHandler
 }

--- a/service/message_bus.go
+++ b/service/message_bus.go
@@ -25,5 +25,6 @@ type MessageBus interface {
 
 	// Subscribe subscribes to the given topic. The event handler
 	// callback will be executed on every received message.
+	// This is a blocking function.
 	Subscribe(_ context.Context, topic string, h EventHandler) error
 }

--- a/service/start.go
+++ b/service/start.go
@@ -87,6 +87,19 @@ func Start(s CloudService) {
 		})
 	}
 
+	// In case the service is subscribed to a message broker, we will listen for
+	// events inside the error group.
+	if events := s.Events(); events != nil { // listen for events
+		bus := s.Bus()
+		if bus == nil {
+			log.Fatalf("Message Bus not initialized")
+		}
+		for e, h := range events {
+			event, handler := e, h
+			g.Go(func() error { return bus.Subscribe(ctx, event, handler) })
+		}
+	}
+
 	// Wait for interrupt signals. Upon receiving one of these signals, the ctx
 	// will be cancelled, initiating a graceful shutdown of the server(s).
 	ch := make(chan os.Signal, 1)


### PR DESCRIPTION
On start-up we check if the service is subscribed for events. If yes, then start listening inside the same error group.