### PR TITLE
CLOUD-20 Conform to the style guide rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,14 +21,29 @@ jobs:
           root: .
           paths: .
 
-  # Run the golang linters using golangci-lint. The linters that will be run are
-  # defined inside the .golangci.yml file.
-  lint:
+  # Make sure that `gofmt` was run.
+  gofmt:
     executor: go-exec
     steps:
       # A special step used to attach the workflow's workspace to the current
       # executor. The full contents of the workspace are downloaded and copied
       # into the directory the workspace is being attached at.
+      - attach_workspace:
+          at: .
+      # Copy the contents of the project into a separate folder, run gofmt, and
+      # check the diff. Note that we are creating a copy of the original
+      # project, because we don't know which is the project folder. If the
+      # project lives inside /tmp then diff will never return true.
+      - run: cp -r ./ /tmp/service_orig
+      - run: cp -r /tmp/service_orig /tmp/service_fmt
+      - run: cd /tmp/service_fmt && go fmt ./...        # gofmt must be run from within the folder
+      - run: diff -r /tmp/service_orig /tmp/service_fmt # exits with error if there is a diff
+
+  # Run the linters.
+  lint:
+    executor: go-exec
+    steps:
+      # Attach the workspace to the current executor.
       - attach_workspace:
           at: .
       # Install golangci-lint, see: https://golangci-lint.run/usage/install/.
@@ -37,7 +52,8 @@ jobs:
             GOLANGCI_LINT_VERSION: v1.55.2
           command: |
             wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT_VERSION}
-      # Run the linters.
+      # Run the golang linters using golangci-lint. The linters that will be run
+      # are defined inside the .golangci.yml file.
       - run: golangci-lint run -v ./...
 
   # Run the unit tests.
@@ -75,7 +91,10 @@ workflows:
       # Pull the src code.
       - pull
 
-      # Linting and testing should run after the code was pulled.
+      # Fmt, lint and tests should run after the code was pulled.
+      - gofmt:
+          requires:
+            - pull
       - lint:
           requires:
             - pull

--- a/pubsub/rabbitmq/bus.go
+++ b/pubsub/rabbitmq/bus.go
@@ -2,8 +2,8 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io"
 	"sync"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -11,8 +11,34 @@ import (
 	"github.com/eventscompass/service-framework/service"
 )
 
-// AMQPBus is a message bus backed by RabbitMQ message broker.
-type AMQPBus struct {
+var (
+	// ErrConnFailed is returned when we cannot establish the
+	// connection.
+	ErrConnFailed = errors.New("connection failed")
+
+	// ErrConnBroken is returned when the connection that we are
+	// trying to use is broken.
+	ErrConnBroken = errors.New("connection broken")
+
+	// ErrConnClosed is returned when the connection that we are
+	// trying to use is closed.
+	ErrConnClosed = errors.New("connection closed")
+
+	// ErrChanBroken is returned when the server channel that we
+	// are trying to use is broken.
+	ErrChanBroken = errors.New("connection channel broken")
+)
+
+// Config holds configuration variables for connecting to a RabbitMQ broker.
+type Config struct {
+	Host     string
+	Port     int
+	Username string
+	Password string
+}
+
+// Bus is a message bus backed by a RabbitMQ message broker.
+type Bus struct {
 	// conn is the connection to the RabbitMQ message broker.
 	conn *amqp.Connection
 
@@ -20,13 +46,12 @@ type AMQPBus struct {
 	exchange string
 }
 
-var (
-	_ service.MessageBus = (*AMQPBus)(nil)
-	_ io.Closer          = (*AMQPBus)(nil)
-)
-
-// NewAMQPBus creates a new [AMQPBus] instance.
-func NewAMQPBus(cfg *service.BusConfig, exchange string) (*AMQPBus, error) {
+// NewAMQPBus creates a new [Bus] instance which can be used to publish events
+// to the given exchange. If you want to publish to a different exchange then
+// simply create a new [Bus] instance, the same broker connection will be
+// re-used. This function returns [ErrConnBroken] in case the connection to the
+// message broker is broken.
+func NewAMQPBus(cfg *Config, exchange string) (*Bus, error) {
 	connInfo := fmt.Sprintf(
 		"amqp://%s:%s@%s:%d", cfg.Username, cfg.Password, cfg.Host, cfg.Port)
 
@@ -36,41 +61,45 @@ func NewAMQPBus(cfg *service.BusConfig, exchange string) (*AMQPBus, error) {
 	once.Do(func() { conn, err = amqp.Dial(connInfo) })
 	if err != nil {
 		// TODO: maybe try using exponential backoff for connecting?
-		return nil, fmt.Errorf("%w: amqp dial: %v", service.ErrUnexpected, err)
+		return nil, fmt.Errorf("%w: dial broker:  %v", ErrConnFailed, err)
 	}
 
 	// Make sure the connection is working by opening a channel on it.
 	ch, err := conn.Channel()
 	if err != nil {
 		_ = conn.Close() //nolint:errcheck // intentional
-		return nil, fmt.Errorf("%w: pubsub channel: %v", service.ErrUnexpected, err)
+		return nil, fmt.Errorf("%w: open channel: %v", ErrConnBroken, err)
 	}
 	defer ch.Close() //nolint:errcheck // intentional
 
-	return &AMQPBus{
+	return &Bus{
 		conn:     conn,
 		exchange: exchange,
 	}, nil
 }
 
-// Publish implements the [service.MessageBus] interface.
-func (b *AMQPBus) Publish(ctx context.Context, topic string, msg []byte) error {
+// Publish publishes a message to a given topic. This function returns
+// [ErrConnClosed] in case the connection to the message broker is closed.
+// This function returns [ErrConnBroken] in case the connection is broken.
+// This function returns [ErrChanBroken] in case operations on the connection
+// channel fail.
+func (b *Bus) Publish(ctx context.Context, topic string, msg []byte) error {
 	if b.conn.IsClosed() {
-		return service.ErrConnectionClosed
+		return ErrConnClosed //nolint:wrapcheck // intentional
 	}
 
 	// Note that AMQP channels are not thread-safe. Thus, we will be creating a
 	// new channel for every published message. By using separate AMQP channels
-	// we can reuse the same AMQP connection.
+	// we can reuse the same AMQP connection concurrently.
 	ch, err := b.conn.Channel()
 	if err != nil {
-		return fmt.Errorf("%w: pubsub channel: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: open channel: %v", ErrConnBroken, err)
 	}
 	defer ch.Close() //nolint:errcheck // intentional
 
 	err = ch.ExchangeDeclare(b.exchange, "topic", true, false, false, false, nil)
 	if err != nil {
-		return fmt.Errorf("%w: exchange declare: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: declare exchange: %v", ErrChanBroken, err)
 	}
 
 	err = ch.PublishWithContext(
@@ -87,43 +116,50 @@ func (b *AMQPBus) Publish(ctx context.Context, topic string, msg []byte) error {
 	if err != nil {
 		// TODO: maybe we should retry publishing.
 		// https://cloud.google.com/pubsub/docs/samples/pubsub-publish-with-error-handler
-		return service.Unexpected(ctx, fmt.Errorf("publish message: %w", err))
+		return fmt.Errorf("%w: publish message: %v", ErrChanBroken, err)
 	}
 	return nil
 }
 
-// Subscribe implements the [service.MessageBus] interface.
-func (b *AMQPBus) Subscribe(
+// Subscribe subscribes to the given topic. The event handler callback will be
+// executed on every received message. This function returns [ErrConnClosed] in
+// case the connection to the message broker is closed. This function returns
+// [ErrConnBroken] in case the connection is broken. This function returns
+// [ErrChanBroken] in case operations on the connection channel fail. This is a
+// blocking function. Canceling the context will cancel the subscription.
+func (b *Bus) Subscribe(
 	ctx context.Context,
 	topic string,
 	eventHandler service.EventHandler,
 ) error {
 	if b.conn.IsClosed() {
-		return service.ErrConnectionClosed
+		return ErrConnClosed //nolint:wrapcheck // intentional
 	}
 
+	// AMQP channels are not thread-safe, thus we need to use a separate channel
+	// for every subscription, so that we can reuse the connection concurrently.
 	ch, err := b.conn.Channel()
 	if err != nil {
-		return fmt.Errorf("%w: pubsub channel: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: open channel: %v", ErrConnBroken, err)
 	}
 	defer ch.Close() //nolint:errcheck // intentional
 
 	// Before binding the queue, make sure the exchange exists.
 	err = ch.ExchangeDeclare(b.exchange, "topic", true, false, false, false, nil)
 	if err != nil {
-		return fmt.Errorf("%w: exchange declare: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: declare exchange: %v", ErrChanBroken, err)
 	}
 
 	// Declare a queue with an arbitrary name and bind it to the exchange.
 	q, err := ch.QueueDeclare("", true, false, false, false, nil)
 	if err != nil {
-		return fmt.Errorf("%w: queue declare: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: declare queue: %v", ErrChanBroken, err)
 	}
 	defer ch.QueueDelete(q.Name, false, false, true) //nolint:errcheck // intentional
 
 	err = ch.QueueBind(q.Name, topic, b.exchange, false, nil)
 	if err != nil {
-		return fmt.Errorf("%w: queue bind: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: bind queue: %v", ErrChanBroken, err)
 	}
 
 	msgs, err := ch.ConsumeWithContext(
@@ -137,24 +173,26 @@ func (b *AMQPBus) Subscribe(
 		nil,    // args
 	)
 	if err != nil {
-		return fmt.Errorf("%w: queue consume: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: consume queue: %v", ErrChanBroken, err)
 	}
 
 	for msg := range msgs {
 		// Pass the message to the event handler.
 		eventHandler(ctx, msg.Body)
 
-		// Ack the message only after we have successfully finished processing.
+		// Ack the message only after we have finished processing.
 		_ = msg.Ack(false) //nolint:errcheck // intentional
 	}
 
 	return nil
 }
 
-// Close implements the [io.Closer] interface.
-func (b *AMQPBus) Close() error {
+// Close closes the connection to the message broker and releases all associated
+// resources. This function returns [ErrConnBroken] if it fails to close the
+// connection.
+func (b *Bus) Close() error {
 	if err := b.conn.Close(); err != nil {
-		return fmt.Errorf("%w: conn close: %v", service.ErrUnexpected, err)
+		return fmt.Errorf("%w: close conn: %v", ErrConnBroken, err)
 	}
 	return nil
 }

--- a/service/config.go
+++ b/service/config.go
@@ -26,11 +26,3 @@ type GRPCConfig struct {
 	// ClientTimeout is a timeout used for RPC HTTP clients. #courier
 	ClientTimeout time.Duration `env:"GRPC_CLIENT_TIMEOUT"`
 }
-
-// BusConfig encapsulates the configuration for the message bus used by the service.
-type BusConfig struct {
-	Host     string `env:"MESSAGE_BUS_HOST" envDefault:"rabbitmq"`
-	Port     int    `env:"MESSAGE_BUS_PORT" envDefault:":5672"`
-	Username string `env:"MESSAGE_BUS_USERNAME" envDefault:"user"`
-	Password string `env:"MESSAGE_BUS_PASSWORD" envDefault:"password"`
-}

--- a/service/message_bus.go
+++ b/service/message_bus.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"io"
 )
 
 // EventHandler is a callback function, which is executed when a subscriber
@@ -14,18 +13,17 @@ type EventHandler func(ctx context.Context, msg []byte)
 // MessageBus defines the interface for publishing messages to a topic and
 // subscribing for receiving messages from a topic.
 type MessageBus interface {
-	io.Closer
 
-	// Publish publishes a message to a given topic. This
-	// function returns [ErrConnectionClosed] in case the
-	// connection to the message broker is closed.
+	// Publish publishes a message to a given topic.
 	Publish(_ context.Context, topic string, msg []byte) error
 
 	// Subscribe subscribes to the given topic. The event handler
 	// callback will be executed on every received message. This
-	// function returns [ErrConnectionClosed] in case the
-	// connection to the message broker is closed. This is a
-	// blocking function. Canceling the context will cancel the
-	// subscription.
+	// is a blocking function. Canceling the context will cancel
+	// the subscription.
 	Subscribe(_ context.Context, topic string, h EventHandler) error
+
+	// Close closes the connection to the MessageBus and releases
+	// all associated resources.
+	Close() error
 }


### PR DESCRIPTION
Update the documentation to conform to the style guide rules defined in the Service-Template repository.
 * update CI pipeline to include a step for ensuring `gofmt` was run
 * remove default MessageBus config, every service should have its own
 * rabbitmq implementation should not depend on the message bus interface: document each method, make sure sensible errors are returned